### PR TITLE
fix approval threshold dropdown and typo

### DIFF
--- a/src/components/Chat/CreateCommonSecret.tsx
+++ b/src/components/Chat/CreateCommonSecret.tsx
@@ -4,7 +4,7 @@ import { CustomizedSnackbars } from '../Snackbar/Snackbar';
 import { LoadingButton } from '@mui/lab';
 import { MyContext, getArbitraryEndpointReact, getBaseApiReact, pauseAllQueues } from '../../App';
 import { getFee } from '../../background';
-import { decryptResource, getGroupAdimns, validateSecretKey } from '../Group/Group';
+import { decryptResource, getGroupAdmins, validateSecretKey } from '../Group/Group';
 import { base64ToUint8Array } from '../../qdn/encryption/group-encryption';
 import { uint8ArrayToObject } from '../../backgroundFunctions/encryption';
 
@@ -51,7 +51,7 @@ export const CreateCommonSecret = ({groupId, secretKey, isOwner,  myAddress, sec
       
      
      
-      const {names} = await getGroupAdimns(groupId);
+      const {names} = await getGroupAdmins(groupId);
       if(!names.length){
         throw new Error('Network error')
       }

--- a/src/components/Group/AddGroup.tsx
+++ b/src/components/Group/AddGroup.tsx
@@ -78,7 +78,7 @@ export const AddGroup = ({ address, open, setOpen }) => {
   };
 
   const handleChangeApprovalThreshold = (event: SelectChangeEvent) => {
-    setGroupType(event.target.value as string);
+    setApprovalThreshold(event.target.value as string);
   };
 
   const handleChangeMinBlock = (event: SelectChangeEvent) => {

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -125,7 +125,7 @@ export const requestQueueAdminMemberNames = new RequestQueueWithPromise(5);
 
 const audio = new Audio(chrome.runtime?.getURL("msg-not1.wav"));
 
-export const getGroupAdimnsAddress = async (groupNumber: number) => {
+export const getGroupAdminsAddress = async (groupNumber: number) => {
   // const validApi = await findUsableApi();
 
   const response = await fetch(
@@ -271,7 +271,7 @@ export async function getNameInfo(address: string) {
   }
 }
 
-export const getGroupAdimns = async (groupNumber: number) => {
+export const getGroupAdmins = async (groupNumber: number) => {
   // const validApi = await findUsableApi();
 
   const response = await fetch(
@@ -725,7 +725,7 @@ export const Group = ({
       const prevGroupId = selectedGroupRef.current.groupId;
       // const validApi = await findUsableApi();
       const { names, addresses, both } =
-        adminsFromStorage || (await getGroupAdimns(selectedGroup?.groupId));
+        adminsFromStorage || (await getGroupAdmins(selectedGroup?.groupId));
       setAdmins(addresses);
       setAdminsWithNames(both);
       if (!names.length) {
@@ -911,7 +911,7 @@ export const Group = ({
 
   const getAdmins = async (groupId) => {
     try {
-      const res = await getGroupAdimnsAddress(groupId);
+      const res = await getGroupAdminsAddress(groupId);
       setAdmins(res);
       const adminsWithNames = await getNamesForAdmins(res);
       setAdminsWithNames(adminsWithNames);


### PR DESCRIPTION
This fixes an issue where the Approval Threshold setting is stuck at 40% when creating a new group, because the onChange function is linked to the Group Type instead.  That causes the group to be set to Open when choosing NONE, or Closed when choosing ONE, and a null value when choosing anything from 20 - 100%.  This also fixes a small typo within the code that is not visible to users.