### PR TITLE
add QR code for QORT and generalize code

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,7 +88,7 @@ import { executeEvent, subscribeToEvent, unsubscribeFromEvent } from "./utils/ev
 import { requestQueueCommentCount, requestQueuePublishedAccouncements } from "./components/Chat/GroupAnnouncements";
 import { requestQueueGroupJoinRequests } from "./components/Group/GroupJoinRequests";
 import { DrawerComponent } from "./components/Drawer/Drawer";
-import { LitecoinQRCode } from "./components/LitecoinQRCode";
+import { AddressQRCode } from "./components/AddressQRCode";
 import { Settings } from "./components/Group/Settings";
 import { MainAvatar } from "./components/MainAvatar";
 
@@ -1260,7 +1260,7 @@ function App() {
               />
             </Box>
           )}
-          <LitecoinQRCode ltcAddress={rawWallet?.ltcAddress} />
+          <AddressQRCode targetAddress={rawWallet?.ltcAddress} />
         </>
       ) : (
         <>
@@ -1346,6 +1346,7 @@ function App() {
           >
             Transfer QORT
           </CustomButton>
+          <AddressQRCode targetAddress={rawWallet?.address0} />
         </>
       )}
       <TextP

--- a/src/components/AddressQRCode.tsx
+++ b/src/components/AddressQRCode.tsx
@@ -4,7 +4,7 @@ import QRCode from 'react-qr-code';
 import { TextP } from '../App-styles';
 import { Box } from '@mui/material';
 
-export const LitecoinQRCode = ({ ltcAddress }) => {
+export const AddressQRCode = ({ targetAddress }) => {
   return (
     <Box sx={{
       display: 'flex',
@@ -22,10 +22,10 @@ export const LitecoinQRCode = ({ ltcAddress }) => {
                   fontWeight: 500,
                 }}
               >
-                Your LTC address
+                Your address
               </TextP>
       <QRCode 
-        value={ltcAddress}  // Your LTC address here
+        value={targetAddress}  // Your address here
         size={180}          // Adjust size as needed
         level="M"           // Error correction level (L, M, Q, H)
         bgColor="#FFFFFF"   // Background color (white)


### PR DESCRIPTION
This adds a QR Code for the QORT wallet, and also makes the QR Code implementation generic, instead of being labelled as specific to Litecoin.